### PR TITLE
Implement `set_translation` import

### DIFF
--- a/mtgsqlive/__init__.py
+++ b/mtgsqlive/__init__.py
@@ -22,7 +22,7 @@ def init_logger() -> None:
             logging.FileHandler(
                 str(
                     LOG_DIR.joinpath(
-                        "mtgsqlive_" + str(time.strftime("%Y-%m-%d_%H:%M:%S")) + ".log"
+                        "mtgsqlive_" + str(time.strftime("%Y-%m-%d_%H-%M-%S")) + ".log"
                     )
                 )
             ),

--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -226,7 +226,7 @@ def parse_and_import_cards(
     :param sql_connection: Database connection
     """
     LOGGER.info("Loading JSON into memory")
-    json_data = json.load(input_file.open("r"))
+    json_data = json.load(input_file.open("r", encoding="utf8"))
 
     LOGGER.info("Building sets")
     for set_code, set_data in json_data.items():

--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -245,6 +245,11 @@ def parse_and_import_cards(
             token_attr = handle_token_row_insertion(token, set_code)
             sql_dict_insert(token_attr, "tokens", sql_connection)
 
+        for language, translation in set_data["translations"].items():
+            LOGGER.debug("Inserting set_translation row for {}".format(language))
+            set_translation_attr = handle_set_translation_row_insertion(language, translation, set_code)
+            sql_dict_insert(set_translation_attr, "set_translations", sql_connection)
+
     sql_connection.commit()
 
 
@@ -359,6 +364,28 @@ def handle_ruling_rows(
             }
         )
     return rulings
+
+
+def handle_set_translation_row_insertion(
+    language: str,
+    translation: str,
+    set_name: str
+) -> Dict[str, Any]:
+    """
+    This method will take the set translation data and convert it, preparing
+    for SQLite insertion
+    :param language: The language of the set translation
+    :param translation: The set name translated in to the given language
+    :param set_name: Set name, as it's a card element
+    :return: Dictionary ready for insertion
+    """
+    set_translation_insert_values: Dict[str, Any] = {
+        "language": language,
+        "translation": translation,
+        "setCode": set_name
+    }
+
+    return set_translation_insert_values
 
 
 def handle_token_row_insertion(


### PR DESCRIPTION
Fixes #16 

This is my first time writing Python, so please let me know if anything is weird and I'll fix it!

I added a section to populate the `set_translations` table.

I also made two tiny fixes so the script would run on Windows:
 - I changed the log file name to use hyphens for the time separator instead of colons, as those are invalid for Windows filenames.
 - I modified the JSON load call to use UTF-8 encoding. For some reason the default on Windows is something else and was causing an error when loading the file.