### PR TITLE
Re-Adding "duelDeck" to tokens table.

### DIFF
--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -241,7 +241,7 @@ def build_sql_schema(sql_connection: sqlite3.Connection) -> None:
         "colorIdentity TEXT,"
         "colorIndicator TEXT,"
         "colors TEXT,"
-        #"duelDeck TEXT,"
+        "duelDeck TEXT,"
         "isOnlineOnly INTEGER NOT NULL DEFAULT 0,"  # boolean
         "layout TEXT,"
         "loyalty TEXT,"

--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -170,6 +170,7 @@ def build_sql_schema(sql_connection: sqlite3.Connection) -> None:
         "colors TEXT,"
         "convertedManaCost FLOAT,"
         "duelDeck TEXT,"
+        "edhrecRank TEXT,"
         "faceConvertedManaCost FLOAT,"
         "flavorText TEXT,"
         "frameEffect TEXT,"
@@ -240,7 +241,7 @@ def build_sql_schema(sql_connection: sqlite3.Connection) -> None:
         "colorIdentity TEXT,"
         "colorIndicator TEXT,"
         "colors TEXT,"
-        "duelDeck TEXT,"
+        #"duelDeck TEXT,"
         "isOnlineOnly INTEGER NOT NULL DEFAULT 0,"  # boolean
         "layout TEXT,"
         "loyalty TEXT,"


### PR DESCRIPTION
Apparently there are still tokens with a "duelDeck" field, so the script currently errors out. It should probably be there for backwards compatibility anyways.