### PR TITLE
Ignore "MtgjsonpricesobjectParentIsCardObject" card price

### DIFF
--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -878,6 +878,8 @@ def handle_price_rows(
     """
     prices = []
     for price_type in card_data["prices"]:
+        if price_type == "MtgjsonpricesobjectParentIsCardObject":
+            continue
         if card_data["prices"][price_type] is not None:
             for date, price in card_data["prices"][price_type].items():
                 if price:


### PR DESCRIPTION
My Python-foo is really low, and I wanted to botch something quickly to get onto something else.

## Problem
https://www.mtgjson.com/files/AllPrintings.sqlite is not being generated correctly (it only creates the tables. The file itself is 72kb).

I tried mtgsqlive locally; and I'm getting:
```py
[INFO] 2020-01-28 11:55:31,507: Building using AllPrintings.json master file.
[INFO] 2020-01-28 11:55:31,622: Building SQLite Schema
[INFO] 2020-01-28 11:55:31,870: Loading JSON into memory
[INFO] 2020-01-28 11:55:36,304: Building sets
[INFO] 2020-01-28 11:55:36,304: Inserting set row for 10E
Traceback (most recent call last):
  File "\Python38\lib\runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "\Python38\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "\mtgsqlive\mtgsqlive\__main__.py", line 64, in <module>
    json2sql.execute(input_file, output_file)
  File "\mtgsqlive\mtgsqlive\json2sql.py", line 45, in execute
    parse_and_import_cards(input_file, output_file)
  File "\mtgsqlive\mtgsqlive\json2sql.py", line 613, in parse_and_import_cards
    card_attr: Dict[str, Any] = handle_card_row_insertion(card, set_code)
  File "\mtgsqlive\mtgsqlive\json2sql.py", line 965, in handle_card_row_insertion
    price_insert_values = handle_price_rows(card_data, card_data["uuid"])
  File "\mtgsqlive\mtgsqlive\json2sql.py", line 882, in handle_price_rows
    for date, price in card_data["prices"][price_type].items():
AttributeError: 'bool' object has no attribute 'items'
```
 
Debugging a bit; I'm getting that `card_data["prices"]` has a `'MtgjsonpricesobjectParentIsCardObject': False` key :confused:.

```py
(Pdb) card_data["prices"]
{'MtgjsonpricesobjectParentIsCardObject': False, 'mtgo': {'2020-01-27': 0.02}, 'mtgoFoil': {'2020-01-27': 0.63}, 'paper': {'2020-01-27': 1.54}, 'paperFoil': {'2020-01-27': 32.82}}
```

## Proposed solution
Skip this weird key.

## Evidence
Now I can generate a `.sqlite` file with the _correct_ size
![image](https://user-images.githubusercontent.com/403456/73261736-f81ceb00-41cc-11ea-864e-113e54f143f0.png)


## Shortcomings
I can't find why that extraneous key is getting there. Maybe it would be smarter to skip any malformed key 🤷‍♀. Or better yet: Find out where the `MtgjsonpricesobjectParentIsCardObject` is coming from.