### PR TITLE
Update MTGJSON version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gitter via [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https:
 
 
 ### Goals
-The goals of this project are to extend the MTGJSONv4 protocols and give an option for pre-processed SQLite downloads.
+The goals of this project are to extend the MTGJSONv5 protocols and give an option for pre-processed SQLite downloads.
 lly edit it to be correct. Once that is accomplished, we are then no longer dependent on them for card data, except for rullings.
 
 # About Us


### PR DESCRIPTION
It's probably even better to remove the version number?
And link to the MTGJSON (or changelog) page instead?

What do you think Zach?