### PR TITLE
feat: Add Postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ To produce a Postgres-ready output, ensure the output file has a `.sql` extensio
 
 ```sh
 # Install dependencies
-$ pip install -r requirements.txt 
+pip install -r requirements.txt 
 
 # usage: mtgsqlive [-h] -i file -o file 
-$ python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sql
+python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sql
 ```
 
 ### Hasura
@@ -57,10 +57,10 @@ If the output file has a `.sql` extension, the destination engine will default t
 
 ```sh
 # Install dependencies
-$ pip install -r requirements.txt 
+pip install -r requirements.txt 
 
 # usage: mtgsqlive [-h] -i file -o file 
-$ python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sql -e mysql
+python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sql -e mysql
 ```  
 
 ## SQLite
@@ -72,8 +72,8 @@ To create a SQLite database, use a `.sqlite` extension for the output file argum
 
 ```sh
 # Install dependencies
-$ pip install -r requirements.txt 
+pip install -r requirements.txt 
 
 # usage: mtgsqlive [-h] -i file -o file 
-$ python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sqlite
+python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sqlite
 ```  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gitter via [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https:
 
 
 ### Goals
-The goals of this project are to extend the MTGJSONv4 protocols and give an option for pre-processed SQLite downloads.
+The goals of this project are to extend the MTGJSONv5 protocols and give an option for pre-processed SQLite downloads.
 lly edit it to be correct. Once that is accomplished, we are then no longer dependent on them for card data, except for rullings.
 
 # About Us
@@ -22,18 +22,58 @@ If you would like to join or assist the development of the project, you can [joi
 
 # How To Use
 
->**Note:** These are the build directions to compile your own SQLite file.<br>
->If you are looking for the pre-compiled SQLite file, you can download it from [MTGJSON.com](https://mtgjson.com/).
+This system was built using *Python 3.9*, so we can only guarantee proper functionality with this version.
 
-This system was built using *Python 3.7*, so we can only guarantee proper functionality with this version.
+## Postgres
 
-
+To produce a Postgres-ready output, ensure the output file has a `.sql` extension.
 
 ```sh
 # Install dependencies
-$ pip3 install -r requirements.txt 
+$ pip install -r requirements.txt 
 
 # usage: mtgsqlive [-h] -i file -o file 
-$ python3 -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sqlite
+$ python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sql
+```
 
+### Hasura
+
+The Postgres-ready output uses JSONB fields to capture array values. This allows for complex filtering if using [Hasura](https://hasura.io/) on top of Postgres to generate a GraphQL schema and API.
+
+For example, if imported into a Hasura instance, one could perform the following query to grab all cards which are both Human and Cleric, then display their names.
+
+```graphql
+query HumanCleric {
+  cards(where: {subtypes: {_contains: ["Human", "Cleric"]}}) {
+    name
+  }
+}
+
+```
+
+## MariaDB/MySQL
+
+If the output file has a `.sql` extension, the destination engine will default to Postgres. The `-e` flag can be set to produce MySQL-conforming output.
+
+```sh
+# Install dependencies
+$ pip install -r requirements.txt 
+
+# usage: mtgsqlive [-h] -i file -o file 
+$ python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sql -e mysql
+```  
+
+## SQLite
+
+To create a SQLite database, use a `.sqlite` extension for the output file argument.
+
+>**Note:** These are the build directions to compile your own SQLite file.<br>
+>If you are looking for the pre-compiled SQLite file, you can download it from [MTGJSON.com](https://mtgjson.com/).
+
+```sh
+# Install dependencies
+$ pip install -r requirements.txt 
+
+# usage: mtgsqlive [-h] -i file -o file 
+$ python -m mtgsqlive -i /path/to/AllPrintings.json -o /path/to/output.sqlite
 ```  

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This system was built using *Python 3.9*, so we can only guarantee proper functi
 
 To produce a Postgres-ready output, ensure the output file has a `.sql` extension.
 
-```sh
+```bash
 # Install dependencies
 pip install -r requirements.txt 
 
@@ -55,7 +55,7 @@ query HumanCleric {
 
 If the output file has a `.sql` extension, the destination engine will default to Postgres. The `-e` flag can be set to produce MySQL-conforming output.
 
-```sh
+```bash
 # Install dependencies
 pip install -r requirements.txt 
 
@@ -70,7 +70,7 @@ To create a SQLite database, use a `.sqlite` extension for the output file argum
 >**Note:** These are the build directions to compile your own SQLite file.<br>
 >If you are looking for the pre-compiled SQLite file, you can download it from [MTGJSON.com](https://mtgjson.com/).
 
-```sh
+```bash
 # Install dependencies
 pip install -r requirements.txt 
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# [**MTGSQLive**](https://mtgjson.com/)
+# MTGSQLive
 
-# Connect With Us
+Create databases from MTGJSON data.
+
+## Connect With Us
 Discord via [![Discord](https://img.shields.io/discord/224178957103136779.svg)](https://discord.gg/74GUQDE)
 
 Gitter via [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/mtgjson/mtgjson4)
 
-
-### Goals
-The goals of this project are to extend the MTGJSONv5 protocols and give an option for pre-processed SQLite downloads.
-lly edit it to be correct. Once that is accomplished, we are then no longer dependent on them for card data, except for rullings.
+# Goals
+The goals of this project are to extend the MTGJSONv5 protocols and give an option for pre-processed SQLite downloads. Once that is accomplished, we are then no longer dependent on them for card data, except for rulings.
 
 # About Us
 
-MTGJSON and MTGSQlive are open sourced database creation and distribution tool for [*Magic: The Gathering*](https://magic.wizards.com/) cards, specifically in [JSON](https://json.org/) and [SQLite](https://www.sqlite.org/index.html) format.
+[MTGJSON](https://mtgjson.com/) and MTGSQlive are open sourced database creation and distribution tool for [*Magic: The Gathering*](https://magic.wizards.com/) cards, specifically in [JSON](https://json.org/) and [SQLite](https://www.sqlite.org/index.html) format.
 
 You can find our documentation with all properties [here](https://mtgjson.com/data-models/).
 

--- a/mtgsqlive/__main__.py
+++ b/mtgsqlive/__main__.py
@@ -37,6 +37,12 @@ if __name__ == "__main__":
         action="store_true",
         required=False,
     )
+    parser.add_argument(
+        "-e",
+        help="SQL database engine ('postgres' or 'mysql'). Only used if output file has .sql extension.",
+        default="postgres",
+        required=False,
+    )
     args = parser.parse_args()
 
     # Define our I/O paths
@@ -59,6 +65,7 @@ if __name__ == "__main__":
             input_file,
             {"path": output_file["path"].joinpath("AllPrintings.sql"), "handle": None},
             args.x,
+            args.e,
         )
 
         logging.info("> Creating AllPrintings CSV components")
@@ -69,4 +76,4 @@ if __name__ == "__main__":
     elif str(input_file).endswith(".sqlite"):
         sql2csv.execute(input_file, output_file)
     else:
-        json2sql.execute(input_file, output_file, args.x)
+        json2sql.execute(input_file, output_file, args.x, args.e)

--- a/mtgsqlive/__main__.py
+++ b/mtgsqlive/__main__.py
@@ -26,21 +26,28 @@ if __name__ == "__main__":
         metavar="fileOut",
     )
     parser.add_argument(
-        "--all",
-        help="Build all types (SQLite, SQL, CSV)",
+        "-a",
+        help="build all types (SQLite, SQL, CSV)",
         action="store_true",
         required=False,
     )
     parser.add_argument(
         "-x",
-        help="Check for extra input files",
+        help="check for extra input files",
         action="store_true",
         required=False,
     )
     parser.add_argument(
         "-e",
-        help="SQL database engine ('postgres' or 'mysql'). Only used if output file has .sql extension.",
+        help="SQL database engine ('postgres' or 'mysql') for .sql output",
         default="postgres",
+        required=False,
+        metavar="engine",
+    )
+    parser.add_argument(
+        "-v",
+        help="verbose output",
+        action="store_true",
         required=False,
     )
     args = parser.parse_args()
@@ -49,7 +56,10 @@ if __name__ == "__main__":
     input_file = pathlib.Path(args.i).expanduser()
     output_file = {"path": pathlib.Path(args.o).expanduser().absolute(), "handle": None}
 
-    if args.all:
+    if args.v:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if args.a:
         logging.info("> Creating AllPrintings.sqlite")
         json2sql.execute(
             input_file,

--- a/mtgsqlive/__main__.py
+++ b/mtgsqlive/__main__.py
@@ -59,13 +59,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Define our I/O paths
-    input_file = pathlib.Path(args.i).expanduser()
-    output_file = {"path": pathlib.Path(args.o).expanduser().absolute(), "handle": None}
+    input_file = pathlib.Path(args.input_file).expanduser()
+    output_file = {"path": pathlib.Path(args.output_file).expanduser().absolute(), "handle": None}
 
-    if args.v:
+    if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    if args.a:
+    if args.all:
         logging.info("> Creating AllPrintings.sqlite")
         json2sql.execute(
             input_file,
@@ -73,15 +73,15 @@ if __name__ == "__main__":
                 "path": output_file["path"].joinpath("AllPrintings.sqlite"),
                 "handle": None,
             },
-            args.x,
+            args.extra,
         )
 
         logging.info("> Creating AllPrintings.sql")
         json2sql.execute(
             input_file,
             {"path": output_file["path"].joinpath("AllPrintings.sql"), "handle": None},
-            args.x,
-            args.e,
+            args.extra,
+            args.engine,
         )
 
         logging.info("> Creating AllPrintings CSV components")
@@ -92,4 +92,4 @@ if __name__ == "__main__":
     elif str(input_file).endswith(".sqlite"):
         sql2csv.execute(input_file, output_file)
     else:
-        json2sql.execute(input_file, output_file, args.x, args.e)
+        json2sql.execute(input_file, output_file, args.extra, args.engine)

--- a/mtgsqlive/__main__.py
+++ b/mtgsqlive/__main__.py
@@ -14,12 +14,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-i",
+        "--input-file",
         help="input source (AllPrintings.json)",
         required=True,
         metavar="fileIn",
     )
     parser.add_argument(
         "-o",
+        "--output-file",
         help="output folder (outputs/)",
         default="outputs",
         required=True,
@@ -27,25 +29,29 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-a",
+        "--all",
         help="build all types (SQLite, SQL, CSV)",
         action="store_true",
         required=False,
     )
     parser.add_argument(
         "-x",
+        "--extra",
         help="check for extra input files",
         action="store_true",
         required=False,
     )
     parser.add_argument(
         "-e",
-        help="SQL database engine ('postgres' or 'mysql') for .sql output",
-        default="postgres",
+        "--engine",
+        help="database engine ('postgres' or 'mysql') for .sql output",
+        default="mysql",
         required=False,
         metavar="engine",
     )
     parser.add_argument(
         "-v",
+        "--verbose",
         help="verbose output",
         action="store_true",
         required=False,

--- a/mtgsqlive/__main__.py
+++ b/mtgsqlive/__main__.py
@@ -6,7 +6,7 @@ import logging
 import pathlib
 
 import mtgsqlive
-from mtgsqlive import sql2csv, json2sql
+from mtgsqlive import json2sql, sql2csv
 
 if __name__ == "__main__":
     mtgsqlive.init_logger()

--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -78,7 +78,7 @@ def check_extra_inputs(input_file: pathlib.Path,
             output_dir[extra] = True
 
 
-def build_sql_database(output_file: str, json_data: JsonDict, engine: Engine) -> None:
+def build_sql_database(output_file: Dict, json_data: JsonDict, engine: Engine) -> None:
     if output_file["path"].suffix == ".sql":
         version = get_version(json_data)
         output_file["handle"] = open(output_file["path"], "w", encoding="utf8")
@@ -153,19 +153,23 @@ def generate_sql_schema(json_data: Dict, output_file: Dict, engine: Engine) -> s
             "date": {"type": "DATE"},
         },
         "legalities": {
-            "format": {"type": "legalities_format" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
-            "status": {"type": "legalities_status" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
+            "format": {
+                "type": "legalities_format" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
+            "status": {
+                "type": "legalities_status" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
         },
         "foreign_data": {
             "flavorText": {"type": "TEXT"},
-            "language": {"type": "foreign_data_language" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
+            "language": {
+                "type": "foreign_data_language" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
             "multiverseid": {"type": "INTEGER"},
             "name": {"type": "TEXT"},
             "text": {"type": "TEXT"},
             "type": {"type": "TEXT"},
         },
         "set_translations": {
-            "language": {"type": "set_translations_language" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
+            "language": {
+                "type": "set_translations_language" if engine == "postgres" else "TEXT" if engine == "sqlite" else "ENUM"},
             "translation": {"type": "TEXT"},
         },
     }
@@ -218,8 +222,7 @@ def generate_sql_schema(json_data: Dict, output_file: Dict, engine: Engine) -> s
                                         if schema[cardKey]["language"]["type"] != "TEXT":
                                             for foreign in cardValue:
                                                 if "options" in schema[cardKey]["language"]:
-                                                    if foreign["language"] not in schema[cardKey]["language"][
-                                                            "options"]:
+                                                    if foreign["language"] not in schema[cardKey]["language"]["options"]:
                                                         schema[cardKey]["language"]["options"].append(
                                                             foreign["language"])
                                                 else:
@@ -270,7 +273,8 @@ def generate_sql_schema(json_data: Dict, output_file: Dict, engine: Engine) -> s
                                 else:
                                     if cardKey in enums[setKey]:
                                         if engine == "postgres":
-                                            schema[setKey][cardKey] = {"type": f"{setKey}_{cardKey}", "options": [cardValue]}
+                                            schema[setKey][cardKey] = {"type": f"{setKey}_{cardKey}",
+                                                                       "options": [cardValue]}
                                         if engine == "mysql":
                                             schema[setKey][cardKey] = {"type": "ENUM", "options": [cardValue]}
                                     else:
@@ -423,7 +427,8 @@ def get_query_from_dict(schema, engine: Engine):
         if engine == "postgres":
             for attribute in sorted(table_data.keys()):
                 if "options" in table_data[attribute]:
-                    q += f"CREATE TYPE {table_data[attribute]['type']} AS ENUM ('" + "', '".join(table_data[attribute]["options"]) + "');\n"
+                    q += f"CREATE TYPE {table_data[attribute]['type']} AS ENUM ('" + "', '".join(
+                        table_data[attribute]["options"]) + "');\n"
             q += f"CREATE TABLE \"{table_name}\" (\n"
         else:
             q += f"CREATE TABLE `{table_name}` (\n"
@@ -448,11 +453,7 @@ def get_query_from_dict(schema, engine: Engine):
     return q
 
 
-def parse_and_import_cards(
-        json_data: Dict,
-        input_file: pathlib.Path,
-        output_file: Dict,
-        engine: Engine) -> None:
+def parse_and_import_cards(json_data: Dict, input_file: pathlib.Path, output_file: Dict, engine: Engine) -> None:
     """
     Parse the JSON cards and input them into the database
 
@@ -807,7 +808,7 @@ def modify_for_sql_insert(data: Any, engine: Engine) -> Union[str, int, float, N
     Arrays and booleans can't be inserted, so we need to stringify
 
     :param data: Data to modify
-    :param data: SQL engine in use
+    :param engine: SQL engine in use
     :return: string value
     """
     if isinstance(data, (str, int, float)):

--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -410,7 +410,7 @@ def get_sql_type(mixed, engine: Engine) -> str:
     The type depends on the SQL engine in some cases
     """
     if isinstance(mixed, list) and engine == "postgres":
-        return "TEXT[]"
+        return "JSONB"
     elif isinstance(mixed, str) or isinstance(mixed, list) or isinstance(mixed, dict):
         return "TEXT"
     elif isinstance(mixed, bool):
@@ -826,7 +826,7 @@ def modify_for_sql_insert(data: Any, engine: Engine) -> Union[str, int, float, N
         return None
 
     if isinstance(data, list) and data and isinstance(data[0], str):
-        return "{\"" + "\",\"".join(data) + "\"}" if engine == "postgres" else ",".join(data)
+        return "[\"" + "\",\"".join(data) + "\"]" if engine == "postgres" else ",".join(data)
 
     if isinstance(data, bool):
         return data if engine == "postgres" else int(data)

--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -324,6 +324,13 @@ def generate_sql_schema(json_data: Dict, output_file: Dict, engine: Engine) -> s
                         if setValue not in schema["sets"][setKey]["options"]:
                             schema["sets"][setKey]["options"].append(setValue)
                 else:
+                    # handle sealed product
+                    if setKey == "sealedProduct":
+                        if engine == "sqlite" or engine == "postgres":
+                            schema["sets"]["sealedProduct"] = {"type": "TEXT"}
+                        else:
+                            schema["sets"]["sealedProduct"] = {"type": "LONGTEXT"}
+                        continue
                     # handle boosters
                     if setKey == "booster":
                         if engine == "sqlite" or engine == "postgres":
@@ -818,10 +825,8 @@ def modify_for_sql_insert(data: Any, engine: Engine) -> Union[str, int, float, N
     if not data:
         return None
 
-    if isinstance(data, list) and engine == "postgres":
-        return "{\"" + "\",\"".join(data) + "\"}"
-    elif isinstance(data, list) and data and isinstance(data[0], str):
-        return ",".join(data)
+    if isinstance(data, list) and data and isinstance(data[0], str):
+        return "{\"" + "\",\"".join(data) + "\"}" if engine == "postgres" else ",".join(data)
 
     if isinstance(data, bool):
         return data if engine == "postgres" else int(data)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.9
 
 check_untyped_defs = True
 disallow_untyped_calls = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-pandas
-argparse
-requests
+.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 # Necessary for TOX
 setuptools.setup(
     name="MTGSQLive",
-    version=0.3,
+    version=0.2,
     author="Zach Halpern",
     author_email="zach@mtgjson.com",
     url="https://github.com/mtgjson/mtgsqlive/",

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import setuptools
 
 # Necessary for TOX
 setuptools.setup(
-    name="MTGSQLite",
-    version=0.2,
+    name="MTGSQLive",
+    version=0.3,
     author="Zach Halpern",
     author_email="zach@mtgjson.com",
     url="https://github.com/mtgjson/mtgsqlive/",
@@ -19,9 +19,14 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT",
     ],
     keywords="Magic: The Gathering, MTG, JSON, Card Games, Collectible, Trading Cards",
     packages=setuptools.find_packages(),
-    install_requires=pathlib.Path("requirements.txt").open().readlines(),
+    install_requires=[
+        "pandas",
+        "argparse",
+        "requests"
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Installation setup for MTGSQLite."""
+"""Installation setup for MTGSQLive."""
 
 import pathlib
 import setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = isort-inplace, black-inplace, mypy, lint
 
 [testenv]
-basepython = python3.7
+basepython = python3.9
 
 [testenv:black-inplace]
 description = Run black and edit all files in place


### PR DESCRIPTION
This PR adds comprehensive Postgres support with the target of allowing easy import of MTGJSON data to a Hasura instance. This adds an `engine` flag to switch between Postgres and MySQL for `.sql` output files. I have tested with both clean Postgres and MySQL instances successfully.