### PR TITLE
Add parquet output, add --formats flag for controlling output formats

### DIFF
--- a/mtgsqlive/parquet.py
+++ b/mtgsqlive/parquet.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import json
+import itertools
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+def execute(json_input: Path, output_file: Path) -> None:
+    """Main function to handle the logic
+    :param json_input: Input file (JSON)
+    :param output_file: Output dir
+    :param extras: additional json files to process
+    """
+    with json_input.open() as fp:
+        parsed = json.load(fp)
+    entities = list(parsed["data"].values())
+    # # Pick only the first printing for each card ID
+    # all_cards = itertools.chain.from_iterable((itertools.islice(set["cards"], 1) for set in sets))
+    df = pd.DataFrame.from_records(entities)
+    # Attach metadata as dictionary
+    table = pa.Table.from_pandas(df, preserve_index=False).replace_schema_metadata(parsed["meta"])
+    pq.write_table(table, str(output_file))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 argparse
 requests
+pyarrow

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 # Necessary for TOX
 setuptools.setup(
     name="MTGSQLite",
-    version=0.2,
+    version='0.2',
     author="Zach Halpern",
     author_email="zach@mtgjson.com",
     url="https://github.com/mtgjson/mtgsqlive/",


### PR DESCRIPTION
The only difficulty is that, I would like the parquet file to have one row per unique card, and put the list of printings inside a list column. However there doesn't seem to be an MTG JSON with this format, and also it's not clear to me if these converters have to take `AllPrintings.json` as input, or if I could use `AllIdentifiers.json` for instance.