### PR TITLE
Ensure columns use JSON instead of Python dicts

### DIFF
--- a/mtgsqlive/json2sql.py
+++ b/mtgsqlive/json2sql.py
@@ -796,7 +796,7 @@ def modify_for_sql_insert(data: Any) -> Union[str, int, float, None]:
         return int(data)
 
     if isinstance(data, dict):
-        return str(data)
+        return json.dumps(data)
 
     return ""
 


### PR DESCRIPTION
This change will fully fix #66

The issue affects all columns that contain Python dictionaries stored via the `str()` method.
So for sure the `leadershipSkills` column and `purchaseUrls` are affected.

This currently has data like:
```
{'brawl': False, 'commander': True, 'oathbreaker': False}
```

This is a valid string version of Python's native `dict` type but is not useful outside of ptyhon.
Given that any language can interact with an SQLite file, but not all of them can decode Pythong dicts - this is sad. 😿 
To fix this it will now `json.dumps` the dict into a valid JSON syntax object.

The after effect is:
```
{"brawl": false, "commander": true, "oathbreaker": false}
```

Happy JSON is happy 😸 

---

The great thing about this PR is that it has the bonus effect of fixing the CSVs as well.
As of RN, the CSVs also would look like:
```
,"{'cardKingdomFoil': 'https://mtgjson.com/links/4e3f626b14b25f54', 'tcgplayer': 'https://mtgjson.com/links/74fc1dd3bbb80489'}",
```

However after the fix they look like:
```
,"{""cardKingdomFoil"": ""https://mtgjson.com/links/4e3f626b14b25f54"", ""tcgplayer"": ""https://mtgjson.com/links/74fc1dd3bbb80489""}",
```

This is important since both Excel and Google Sheets will support JSON methods, but don't support python dicts.
* Excel: https://support.microsoft.com/en-us/office/parse-text-as-json-or-xml-power-query-7436916b-210a-4299-83dd-8531a1d5e945
* Sheets: Done via Apps Script