### PR TITLE
Add boosterName and unique constraint for relevant tables

### DIFF
--- a/mtgsqlive/converters/parents/abstract.py
+++ b/mtgsqlive/converters/parents/abstract.py
@@ -191,11 +191,12 @@ class AbstractConverter(abc.ABC):
 
     def get_next_booster_sheets_entry(self) -> Iterator[Dict[str, str | bool]]:
         for set_code, set_data in self.mtgjson_data["data"].items():
-            for booster_object in set_data.get("booster", {}).values():
+            for booster_name, booster_object in set_data.get("booster", {}).items():
                 for sheet_name, sheet_contents in booster_object["sheets"].items():
                     yield {
                         "setCode": set_code,
                         "sheetName": sheet_name,
+                        "boosterName": booster_name,
                         "sheetIsFoil": sheet_contents.get("foil", False),
                         "sheetHasBalanceColors": sheet_contents.get(
                             "balanceColors", False
@@ -204,12 +205,13 @@ class AbstractConverter(abc.ABC):
 
     def get_next_booster_sheet_cards_entry(self) -> Iterator[Dict[str, str | int]]:
         for set_code, set_data in self.mtgjson_data["data"].items():
-            for booster_object in set_data.get("booster", {}).values():
+            for booster_name, booster_object in set_data.get("booster", {}).items():
                 for sheet_name, sheet_contents in booster_object["sheets"].items():
                     for card_uuid, card_weight in sheet_contents["cards"].items():
                         yield {
                             "setCode": set_code,
                             "sheetName": sheet_name,
+                            "boosterName": booster_name,
                             "cardUuid": card_uuid,
                             "cardWeight": card_weight,
                         }


### PR DESCRIPTION
This should fix https://github.com/mtgjson/mtgsqlive/issues/96 . 

This PR adds `boosterName` as a column to `setBoosterSheets` and `setBoosterSheetCards`. Sheets can have the same name across packs but have different weights and contents as per `taw` [on discord](https://discord.com/channels/224178957103136779/448295284137656342/1146100702725296188).

A better schema design would likely be to add a foreign key to table of setName, sheetName, boosterName to minimize disk space. However, that would be a large breaking change for existing users.

I also added a unique constraint to these tables to help mitigate a similar problem from occurring in the future.

If there is a different preferred approach please let me know!